### PR TITLE
Infra - 4609 :: Keep snowflake connection alive

### DIFF
--- a/pgwarehouse/snowflake_backend.py
+++ b/pgwarehouse/snowflake_backend.py
@@ -45,7 +45,8 @@ class SnowflakeBackend(Backend):
             'password': self.snowsql_pwd,
             'account': self.snowsql_account,
             'database': self.snowsql_database,
-            'schema': self.snowsql_schema
+            'schema': self.snowsql_schema,
+            'client_session_keep_alive': True
         }
         if self.snowsql_role:
             connection_config.update({'role': self.snowsql_role})


### PR DESCRIPTION
Our process takes too much time and timeout our connection to snowflake. This should ensure we have enough time.