### PR TITLE
chore: allow snowflake-connector-python 4.x and pytest 9.x

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -968,4 +968,4 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "16a9a60f449858deb44267f44f08a0aae786db3cb040ba05044ab5d53798f8c3"
+content-hash = "15daf13a9610110461171072c8b68de2c49e176ababe197e502e73069863585f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,10 @@ pyyaml = "^6.0.1"
 python-dotenv = "^1.0.1"
 clickhouse-driver = "^0.2.7"
 psycopg2 = "^2.9.9"
-snowflake-connector-python = "^3.10.0"
+snowflake-connector-python = ">=3.10.0,<5.0.0"
 tabulate = "^0.9.0"
 testing-postgresql = "^1.3.0"
-pytest = "^8.2.0"
+pytest = ">=8.2.0,<10.0.0"
 duckdb = "^0.10.2"
 
 


### PR DESCRIPTION
## Summary

Widen two version caps in `pyproject.toml` that block downstream consumers from taking security patches:

- `snowflake-connector-python`: `^3.10.0` → `>=3.10.0,<5.0.0`
- `pytest`: `^8.2.0` → `>=8.2.0,<10.0.0`

## Why

The `^3.10.0` cap forces `snowflake-connector-python < 4.0.0`. Snowflake <4 transitively pins `pyOpenSSL < 25` → `cryptography < 45`, which keeps consumers stuck on **vulnerable `cryptography` and `pyOpenSSL` versions (both HIGH advisories)**. The `^8.2.0` cap likewise blocks `pytest` 9.x.

This surfaced while remediating Dependabot alerts in `data-quality-synchronization`, which installs `pgwarehouse` as a git dependency — its `pyproject.toml` caps propagate as hard constraints into the consumer's lock.

## Safety

`pgwarehouse`'s Snowflake usage (`snowflake_backend.py`) is limited to `connect` / `cursor()` / `execute()` / `fetch*()` and plain SQL (`PUT`, `COPY INTO`, `CREATE TABLE`, etc.) — all stable APIs unchanged across the 3.x → 4.x major. No use of the pandas/arrow surface that changed in 4.x. The wider range lets each consumer's environment resolve the newest compatible version.

`poetry.lock` content-hash updated (minimal churn, same lock format); `poetry check --lock` passes.

## Follow-up

Once merged, `data-quality-synchronization` will point its `pgwarehouse` ref here and re-lock, which clears the remaining `cryptography` / `pyOpenSSL` / `pytest` alerts there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)